### PR TITLE
Add QUnit tests for chrome extension

### DIFF
--- a/browser_proxy__chrome_ext/package.json
+++ b/browser_proxy__chrome_ext/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "browser_proxy_chrome_ext",
+  "version": "0.1.0",
+  "devDependencies": {
+    "qunit": "^2.20.0"
+  },
+  "scripts": {
+    "test": "qunit"
+  }
+}

--- a/browser_proxy__chrome_ext/tests/content.test.js
+++ b/browser_proxy__chrome_ext/tests/content.test.js
@@ -1,0 +1,70 @@
+const path = require('path');
+
+// capture console.log output
+let logs = [];
+const origConsoleLog = console.log;
+console.log = (...args) => {
+  logs.push(args.join(' '));
+};
+
+// stub performance API
+const performance = {
+  entries: [],
+  observers: [],
+  getEntriesByType(type) {
+    if (type === 'resource') return this.entries;
+    return [];
+  },
+  addEntry(name) {
+    const entry = { name };
+    this.entries.push(entry);
+    for (const obs of this.observers) {
+      obs.callback({ getEntries: () => [entry] });
+    }
+  }
+};
+
+global.performance = performance;
+
+global.PerformanceObserver = class {
+  constructor(callback) {
+    this.callback = callback;
+  }
+  observe() {
+    performance.observers.push(this);
+  }
+};
+
+const loadExtension = () => {
+  const extPath = path.join(__dirname, '..', 'content.js');
+  delete require.cache[require.resolve(extPath)];
+  require(extPath);
+};
+
+QUnit.module('content.js', hooks => {
+  hooks.beforeEach(() => {
+    logs = [];
+    performance.entries = [];
+    performance.observers = [];
+  });
+
+  QUnit.test('logs existing resources on load', assert => {
+    performance.entries = [{ name: 'a.js' }, { name: 'b.css' }];
+    loadExtension();
+
+    assert.ok(logs.includes('Resource loaded: a.js'), 'logs initial a.js');
+    assert.ok(logs.includes('Resource loaded: b.css'), 'logs initial b.css');
+  });
+
+  QUnit.test('logs future resource loads', assert => {
+    loadExtension();
+    performance.addEntry('c.js');
+
+    assert.ok(logs.includes('Resource loaded: c.js'), 'logs new resource');
+  });
+});
+
+// cleanup
+delete global.performance;
+delete global.PerformanceObserver;
+console.log = origConsoleLog;

--- a/browser_proxy__chrome_ext/wallaby.js
+++ b/browser_proxy__chrome_ext/wallaby.js
@@ -1,0 +1,15 @@
+module.exports = function (wallaby) {
+  return {
+    files: [
+      'content.js',
+      'manifest.json'
+    ],
+    tests: [
+      'tests/**/*.test.js'
+    ],
+    testFramework: 'qunit',
+    env: {
+      kind: 'chrome'
+    }
+  };
+};


### PR DESCRIPTION
## Summary
- set up QUnit tests for the chrome extension
- provide Wallaby configuration
- add package.json for test dependencies

## Testing
- `pip install -r requirements-test.txt` *(fails: cannot connect to proxy)*