### PR TITLE
Use Pyodide to generate log messages

### DIFF
--- a/browser_proxy__chrome_ext/content.js
+++ b/browser_proxy__chrome_ext/content.js
@@ -1,13 +1,27 @@
-(function() {
+(async function() {
+  // Load Pyodide from CDN
+  const pyodide = await loadPyodide({indexURL: 'https://cdn.jsdelivr.net/pyodide/v0.23.4/full/'});
+
+  // Load Python helper module bundled with the extension
+  const response = await fetch(chrome.runtime.getURL('message.py'));
+  const pythonCode = await response.text();
+  await pyodide.runPythonAsync(pythonCode);
+  const formatMessage = pyodide.globals.get('format_message');
+
+  function logResource(name) {
+    const msg = formatMessage(name);
+    console.log(msg);
+  }
+
   // Log already loaded resources
   performance.getEntriesByType('resource').forEach(entry => {
-    console.log('Resource loaded:', entry.name);
+    logResource(entry.name);
   });
 
   // Observe future resource loads
   const observer = new PerformanceObserver(list => {
     list.getEntries().forEach(entry => {
-      console.log('Resource loaded:', entry.name);
+      logResource(entry.name);
     });
   });
 

--- a/browser_proxy__chrome_ext/manifest.json
+++ b/browser_proxy__chrome_ext/manifest.json
@@ -9,5 +9,8 @@
       "js": ["content.js"],
       "run_at": "document_start"
     }
+  ],
+  "host_permissions": [
+    "https://cdn.jsdelivr.net/*"
   ]
 }

--- a/browser_proxy__chrome_ext/message.py
+++ b/browser_proxy__chrome_ext/message.py
@@ -1,0 +1,5 @@
+
+def format_message(url: str) -> str:
+    """Return a log message for a loaded resource."""
+    return f"Resource loaded from Python: {url}"
+


### PR DESCRIPTION
## Summary
- run Pyodide in the chrome extension
- call a small Python helper to format log messages
- allow fetching Pyodide from the CDN

## Testing
- `pytest -q` *(fails: command not found)*